### PR TITLE
Add Compute admin

### DIFF
--- a/manifests/admin.py
+++ b/manifests/admin.py
@@ -171,15 +171,30 @@ class ModemAdmin(admin.ModelAdmin):
         return redirect("..")
 
 
+@admin.register(Compute)
+class ComputeAdmin(admin.ModelAdmin):
+    list_display = ["name", "node", "hardware", "serial_no", "zone"]
+    list_filter = ["hardware", "zone"]
+    search_fields = ["name", "node__vsn", "hardware__hardware", "serial_no", "zone"]
+    autocomplete_fields = ["node", "hardware"]
+
+
+admin.site.register(
+    ComputeHardware,
+    list_display=["hardware", "hw_model", "manufacturer"],
+    search_fields=["name"],
+)
+admin.site.register(
+    SensorHardware,
+    list_display=["hardware", "hw_model", "manufacturer"],
+    search_fields=["name"],
+)
+admin.site.register(
+    ResourceHardware,
+    list_display=["hardware", "hw_model", "manufacturer"],
+    search_fields=["name"],
+)
+
 admin.site.register(Label)
 admin.site.register(Tag)
-admin.site.register(
-    ComputeHardware, list_display=["hardware", "hw_model", "manufacturer"]
-)
-admin.site.register(
-    SensorHardware, list_display=["hardware", "hw_model", "manufacturer"]
-)
-admin.site.register(
-    ResourceHardware, list_display=["hardware", "hw_model", "manufacturer"]
-)
 admin.site.register(Capability)

--- a/manifests/admin.py
+++ b/manifests/admin.py
@@ -69,7 +69,7 @@ class NodeAdmin(nested_admin.NestedModelAdmin):
         "get_tags",
         "get_computes",
     )
-    search_fields = ("vsn", "name")
+    search_fields = ("vsn", "name", "compute__name")
     ordering = ("vsn",)
 
     fieldsets = (
@@ -182,7 +182,14 @@ class ComputeAdmin(nested_admin.NestedModelAdmin):
         "get_sensors",
     ]
     list_filter = ["hardware", "zone"]
-    search_fields = ["name", "node__vsn", "hardware__hardware", "serial_no", "zone"]
+    search_fields = [
+        "name",
+        "node__vsn",
+        "hardware__hardware",
+        "serial_no",
+        "zone",
+        "computesensor__name",
+    ]
     autocomplete_fields = ["node", "hardware"]
     inlines = [ComputeSensorInline]
 

--- a/manifests/models.py
+++ b/manifests/models.py
@@ -164,6 +164,9 @@ class AbstractSensor(models.Model):
     class Meta:
         abstract = True
 
+    def __str__(self):
+        return self.name
+
 
 class NodeSensor(AbstractSensor):
     node = models.ForeignKey(NodeData, on_delete=models.CASCADE, blank=True)
@@ -178,9 +181,6 @@ class Resource(models.Model):
     node = models.ForeignKey(NodeData, on_delete=models.CASCADE, blank=True)
     hardware = models.ForeignKey(ResourceHardware, on_delete=models.CASCADE, blank=True)
     name = models.CharField(max_length=30, blank=True)
-
-    def __str__(self):
-        return self.name
 
 
 class Tag(models.Model):


### PR DESCRIPTION
This PR adds a standalone Compute admin section to help quickly find and manage inventory at the compute level.

This is intended to complement the node centric admin view in cases where we may have moved a shield or device between nodes.