### PR TITLE
Replace capabilities IDs by their names for /sensors

### DIFF
--- a/manifests/serializers.py
+++ b/manifests/serializers.py
@@ -3,9 +3,14 @@ from .models import *
 
 
 class SensorHardwareSerializer(serializers.ModelSerializer):
+    # replace capabilities IDs by their names
+    capabilities = serializers.SlugRelatedField(many=True, read_only=True, slug_field="capability", required=False)
+
     class Meta:
         model = SensorHardware
-        exclude = ["id"]
+        # to preserve the fields order, we'll list them explicitly
+        fields = ["hardware", "hw_model", "hw_version", "sw_version", "manufacturer", "datasheet", "description",
+                  "capabilities"]
 
 
 class ModemSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Replace capabilities IDs (list of int) by their names (list of string) for the '/sensors' endpoint. For example:
```
    {
         ...
        "capabilities": [
            31
        ]
    }
```

will be:
```
    {
         ...
        "capabilities": [
            "camera"
        ]
    }
```