### PR TITLE
Add admin for node and compute sensors

### DIFF
--- a/manifests/models.py
+++ b/manifests/models.py
@@ -199,6 +199,9 @@ class NodeSensor(AbstractSensor):
 class ComputeSensor(AbstractSensor):
     scope = models.ForeignKey(Compute, on_delete=models.CASCADE, blank=True)
 
+    def node(self):
+        return self.scope.node
+
 
 class Resource(models.Model):
     node = models.ForeignKey(NodeData, on_delete=models.CASCADE, blank=True)


### PR DESCRIPTION
This PR adds admin interfaces for node and compute sensors in order to allow a global view and search across all sensors on all nodes and computes.
