### PR TITLE
Add node users endpoint to support user accounts

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
         "portal-logout/", views.LogoutView.as_view(redirect_field_name="callback")
     ),  # for portal compatibility
     path("nodes/<str:vsn>/authorized_keys", views.NodeAuthorizedKeysView.as_view()),
+    path("nodes/<str:vsn>/users", views.NodeUsersView.as_view()),
 ] + format_suffix_patterns(
     [
         # token views


### PR DESCRIPTION
This PR add a `/nodes/{vsn}/users` endpoint which provides the list of users and their ssh public keys like:
```
[
    {
        "user": "someuser",
        "ssh_public_keys": "ssh-ed25519 AAAA...\n"
    },
   ...
]
```

This will enable automation of per user accounts on nodes for developer access.