### PR TITLE
Faster node endpoint

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -13,3 +13,10 @@ DATABASES = {
         "NAME": BASE_DIR / "db.sqlite3",
     }
 }
+
+#debug toolbar requirements
+INSTALLED_APPS.append("debug_toolbar")
+MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
+INTERNAL_IPS = [
+    "127.0.0.1",
+]

--- a/config/urls.py
+++ b/config/urls.py
@@ -39,4 +39,5 @@ urlpatterns = [
         name="oauth2-redirect",
     ),
     path("downloads/", include("downloads.urls")),
+    path("_debug/", include("debug_toolbar.urls"))
 ]

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.conf import settings
 from django.contrib import admin
 from django.urls import path, include
@@ -39,5 +40,9 @@ urlpatterns = [
         name="oauth2-redirect",
     ),
     path("downloads/", include("downloads.urls")),
-    path("_debug/", include("debug_toolbar.urls"))
 ]
+
+if settings.DEBUG:
+    urlpatterns += [
+        path("_debug/", include("debug_toolbar.urls")),
+    ]

--- a/manifests/serializers.py
+++ b/manifests/serializers.py
@@ -38,7 +38,8 @@ class SensorViewSerializer(serializers.ModelSerializer):
             nodes = [
                 node
                 for node in nodes
-                if node.phase.lower() in (p.lower() for p in phases)
+                if node.phase
+                and node.phase.lower() in (p.lower() for p in phases)
             ]
 
         vsns = sorted(set([node.vsn for node in nodes]))

--- a/manifests/views.py
+++ b/manifests/views.py
@@ -44,6 +44,7 @@ class ManifestViewSet(ReadOnlyModelViewSet):
                 "compute_set__computesensor_set__hardware__capabilities",
                 "compute_set__computesensor_set__labels",
                 "resource_set__hardware__capabilities",
+                "lorawanconnections__lorawan_device__hardware__capabilities",
                 "tags",
             )
             .order_by("vsn")

--- a/manifests/views.py
+++ b/manifests/views.py
@@ -203,10 +203,11 @@ class NodesViewSet(ReadOnlyModelViewSet):
     queryset = (
         NodeData.objects.all()
         .prefetch_related(
-            "nodesensor_set",
-            "compute_set",
-            "lorawanconnections",
-            "modem"
+            "modem",
+            "lorawanconnections__lorawan_device__hardware__capabilities",
+            "compute_set__hardware__capabilities",
+            "nodesensor_set__hardware__capabilities",
+            "project",
         )
         .order_by("vsn")
     )

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,3 +16,6 @@ django-filter==23.5
 git+https://github.com/waggle-sensor/django-address
 # setuptools needed for python 3.12+
 setuptools==69.2.0
+# NOTE(sean) I'm installing django-debug-toolbar in base to make the collectstatic step work
+# when building the image. We can revisit this later if we want to move it to just prod.
+django-debug-toolbar==4.3.0 # enables a debug toolbar, helps with debugging api endpoints

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,3 +6,4 @@ djangorestframework-stubs==3.14.2    # better type hints for django rest framewo
 pytest-django==4.7.0                 # better testing
 pytest-cov==4.1.0                    # includes coverage report when testing with pytest
 pytest-xdist==3.5.0                  # allows for running tests on multiple processes for faster testing
+django-debug-toolbar==4.*            # enables a debug toolbar, helps with debugging api endpoints

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,4 +6,3 @@ djangorestframework-stubs==3.14.2    # better type hints for django rest framewo
 pytest-django==4.7.0                 # better testing
 pytest-cov==4.1.0                    # includes coverage report when testing with pytest
 pytest-xdist==3.5.0                  # allows for running tests on multiple processes for faster testing
-django-debug-toolbar==4.*            # enables a debug toolbar, helps with debugging api endpoints


### PR DESCRIPTION
# Summary

Updates to make api endpoint faster.

## /api/v-beta/nodes/
Before updates:
```sh
% time curl http://127.0.0.1:8000/api/v-beta/nodes/ > /dev/null 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  157k  100  157k    0     0   216k      0 --:--:-- --:--:-- --:--:--  216k
0.01s user 0.01s system 2% cpu 0.752 total
```
After updates:
```sh
% time curl http://127.0.0.1:8000/api/v-beta/nodes/ > /dev/null 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  157k  100  157k    0     0  1370k      0 --:--:-- --:--:-- --:--:-- 1378k
0.01s user 0.01s system 10% cpu 0.131 total
```

- After updates, sql queries went from 750 to 15.

## /manifests/
Before updates:
```sh  
% time curl http://127.0.0.1:8000/manifests/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1742k  100 1742k    0     0  1198k      0  0:00:01  0:00:01 --:--:-- 1198k
0.01s user 0.01s system 1% cpu 1.480 total
```
After updates:
```sh
% time curl http://127.0.0.1:8000/manifests/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 1742k  100 1742k    0     0  7297k      0 --:--:-- --:--:-- --:--:-- 7323k
0.01s user 0.01s system 6% cpu 0.260 total
```

- After updates, sql queries went from 249 to 24.

## /computes/
Before updates:
```sh  
% time curl http://127.0.0.1:8000/computes/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 40429  100 40429    0     0  21519      0  0:00:01  0:00:01 --:--:-- 21516
0.01s user 0.01s system 0% cpu 1.899 total
```
After updates:
```sh
% time curl http://127.0.0.1:8000/computes/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 40429  100 40429    0     0  1099k      0 --:--:-- --:--:-- --:--:-- 1128k
0.01s user 0.01s system 25% cpu 0.052 total
```

- After updates, sql queries went from 851 to 5.

## /sensors/
Before updates:
```sh  
% time curl http://127.0.0.1:8000/sensors/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 32806  100 32806    0     0   219k      0 --:--:-- --:--:-- --:--:--  220k
0.01s user 0.01s system 9% cpu 0.173 total
```
After updates:
```sh
% time curl http://127.0.0.1:8000/sensors/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 32806  100 32806    0     0   498k      0 --:--:-- --:--:-- --:--:--  500k
0.01s user 0.01s system 16% cpu 0.081 total
```

- After updates, sql queries went from 39 to 12.

## /node-builds/
Before updates:
```sh  
% time curl http://127.0.0.1:8000/node-builds/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 52502  100 52502    0     0   201k      0 --:--:-- --:--:-- --:--:--  202k
0.01s user 0.01s system 5% cpu 0.273 total
```
After updates:
```sh
% time curl http://127.0.0.1:8000/node-builds/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 52502  100 52502    0     0  1411k      0 --:--:-- --:--:-- --:--:-- 1424k
0.01s user 0.01s system 26% cpu 0.054 total
```

- After updates, sql queries went from 223 to 8.

## /lorawandevices/
Before updates:
```sh  
% time curl http://127.0.0.1:8000/lorawandevices/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    58  100    58    0     0   1095      0 --:--:-- --:--:-- --:--:--  1115
0.01s user 0.01s system 18% cpu 0.070 total
```
After updates:
```sh
% time curl http://127.0.0.1:8000/lorawandevices/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    58  100    58    0     0   1317      0 --:--:-- --:--:-- --:--:--  1348
0.01s user 0.01s system 22% cpu 0.061 total
```

- After updates, sql queries went from 9 to 7.

## /lorawanconnections/
Before updates:
```sh  
% time curl http://127.0.0.1:8000/lorawanconnections/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    58  100    58    0     0   1373      0 --:--:-- --:--:-- --:--:--  1380
0.01s user 0.01s system 23% cpu 0.061 total
```
After updates:
```sh
% time curl http://127.0.0.1:8000/lorawanconnections/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    58  100    58    0     0   4219      0 --:--:-- --:--:-- --:--:--  4461
0.01s user 0.01s system 42% cpu 0.030 total
```

## /sensorhardwares/
Before updates:
```sh  
% time curl http://127.0.0.1:8000/sensorhardwares/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    58  100    58    0     0   3175      0 --:--:-- --:--:-- --:--:--  3222
0.01s user 0.01s system 40% cpu 0.040 total
```
After updates:
```sh
% time curl http://127.0.0.1:8000/sensorhardwares/ > /dev/null
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    58  100    58    0     0   4213      0 --:--:-- --:--:-- --:--:--  4461
0.01s user 0.01s system 43% cpu 0.030 total
```

- After updates, sql queries went from 31 to 6.
